### PR TITLE
fix: build error of files built by newer tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "swr": "^0.5.5",
     "ts-loader": "^6.2.1",
     "turbolinks": "^5.2.0",
-    "typescript": "^3.7.5",
+    "typescript": "4.0.5",
     "y18n": "4.0.1",
     "yargs-parser": "^5.0.0-security.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7608,10 +7608,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^3.7.5:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
-  integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
+typescript@4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 uncontrollable@^7.0.0:
   version "7.1.1"


### PR DESCRIPTION
In previous PR #9, it add a new dependency named react-use, for simplifying the state manage. It is built by typescript 4.x.y, but in our current build config, we use and old version Typescript(3.7). Therefore, it can not handle with the newer dts file.

In this PR, I update the Typescript version from 3.7.5 to 4.0.5. I have tested the project can build without any errors.