### PR TITLE
fix: should init balance if last month not claimed maximum capacity

### DIFF
--- a/app/services/claim_service.rb
+++ b/app/services/claim_service.rb
@@ -33,13 +33,12 @@ class ClaimService
   end
 
   private
-
   def init_account!
     account = Account.create_or_find_by!(address_hash: address_hash)
     value = Rails.cache.read("LIMIT_#{address_hash}")
-    if value && value.month != Date.today.month
+    if (value && value.month != Date.today.month) || account.updated_at.month != Date.today.month
       account.update!(balance: 0)
-      Rails.cache.delete("LIMIT#{address_hash}")
+      Rails.cache.delete("LIMIT_#{address_hash}")
     end
   end
 end


### PR DESCRIPTION
If last month not claimed maximum capacity, next month should init balance.