### PR TITLE
Update Welcome.tsx

### DIFF
--- a/app/javascript/components/Welcome.tsx
+++ b/app/javascript/components/Welcome.tsx
@@ -217,7 +217,7 @@ const Welcome: React.FC<WelcomeProps> = ({
               xl="5"
               className="justify-content-center content-container"
             >
-              <p>Every address can claim a fixed amount of 300,000 CKB in a month. The claimable amount will monthly update on the first day when you claim on this site.</p>
+              <p>Every address can claim a maximum of 300,000 CKB per calendar month.</p>
             </Col>
           </Row>
           <Row className="justify-content-center align-items-center">


### PR DESCRIPTION
the original message was confusing and grammatically incorrect. Changing it to "Every address can claim a maximum of 300,000 CKB per calendar month." effectively conveys the message that for each specific address or user, there is a limit of 300,000 CKB that they can claim within a single calendar month. This claimable amount resets at the start of each new month, allowing users to claim up to 300,000 CKB again in the following month.